### PR TITLE
Native python converters for HBaseResult and others

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 lazy val root = (project in file(".")).
   settings(
     name := "spark_hbase",
-    version := "1.0",
+    version := "1.1",
     scalaVersion := "2.10.5",
     sparkVersion := "1.3.0"
   )
 
 libraryDependencies ++= Seq(
-  "org.apache.hbase" % "hbase" % "0.98.8-hadoop2",
-  "org.apache.hbase" % "hbase-client" % "0.98.8-hadoop2",
-  "org.apache.hbase" % "hbase-common" % "0.98.8-hadoop2",
-  "org.apache.hbase" % "hbase-server" % "0.98.8-hadoop2"
+  "org.apache.hbase" % "hbase" % "1.0.0",
+  "org.apache.hbase" % "hbase-client" % "1.0.0",
+  "org.apache.hbase" % "hbase-common" % "1.0.0",
+  "org.apache.hbase" % "hbase-server" % "1.0.0"
 )
 
 mergeStrategy in assembly := {

--- a/src/main/scala/examples/pythonConverters.scala
+++ b/src/main/scala/examples/pythonConverters.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.hbase.CellUtil
 /**
  * Implementation of [[org.apache.spark.api.python.Converter]] that converts all 
  * the records in an HBase Result to a String. In the String, it contains row, column,
- * qualifier, timesstamp, type and value
+ * qualifier, timestamp, type and value
  */
 
 class HBaseResultToStringConverter extends Converter[Any, String]{
@@ -54,6 +54,11 @@ class HBaseResultToStringConverter extends Converter[Any, String]{
   }
 }
 
+/**
+ * Implementation of [[org.apache.spark.api.python.Converter]] that converts all 
+ * the records in an HBase Result to a String. In the String, it contains row, column,
+ * qualifier, timestamp, type and value, all packed as JSON
+ */
 class HBaseResultToJSONConverter extends Converter[Any, String]{
   override def convert(obj: Any): String = {
     import collection.JavaConverters._
@@ -73,6 +78,11 @@ class HBaseResultToJSONConverter extends Converter[Any, String]{
   }
 }
 
+/**
+ * Implementation of [[org.apache.spark.api.python.Converter]] that converts all 
+ * the records in an HBase Result into a list of maps, each containing row, column,
+ * qualifier, timestamp, type and value
+ */
 class HBaseRawResultsConverter extends Converter[Any, java.util.List[java.util.Map[String, String]]]{
   override def convert(obj: Any): java.util.List[java.util.Map[String, String]] = {
     import collection.JavaConverters._
@@ -91,8 +101,9 @@ class HBaseRawResultsConverter extends Converter[Any, java.util.List[java.util.M
   }
 }
 
-/* Map of "columnFamily:column"->"value" consistent with Python dict
- Only works with 1 version max.  Ser/deser as python dict naturally, via HashMap
+/**
+ * Map of "columnFamily:column"->"value" consistent with Python dict
+ * Only works with 1 version max.  Ser/deser as python dict naturally, via HashMap
  */
 class HBaseResultToMapConverter extends Converter[Any, java.util.Map[String, String]]{
   override def convert(obj: Any): java.util.Map[String, String] = {
@@ -112,7 +123,10 @@ class HBaseResultToMapConverter extends Converter[Any, java.util.Map[String, Str
   }
 }
 
-/* Returns the most recent cell timestamp on the row */
+/**
+ * Returns the most recent cell timestamp on the row as a long integer, useful for 
+ * operations that require syncing to data changes.
+ */
 class MaxHBaseTimestamp extends Converter[Any, Long]{
   override def convert(obj: Any): Long = {
     import collection.JavaConverters._
@@ -127,7 +141,6 @@ class MaxHBaseTimestamp extends Converter[Any, Long]{
  * Implementation of [[org.apache.spark.api.python.Converter]] that converts an
  * ImmutableBytesWritable to a String
  */
-
 class ImmutableBytesWritableToStringConverter extends Converter[Any, String] {
   override def convert(obj: Any): String = {
     val key = obj.asInstanceOf[ImmutableBytesWritable]

--- a/src/main/scala/examples/pythonConverters.scala
+++ b/src/main/scala/examples/pythonConverters.scala
@@ -81,9 +81,10 @@ class HBaseResultToJSONConverter extends Converter[Any, String]{
 /**
  * Implementation of [[org.apache.spark.api.python.Converter]] that converts all 
  * the records in an HBase Result into a list of maps, each containing row, column,
- * qualifier, timestamp, type and value
+ * qualifier, timestamp, type and value.  Values are returned as raw bytes rather than as
+ * printable versions, and thus may require unpacking.
  */
-class HBaseRawResultsConverter extends Converter[Any, java.util.List[java.util.Map[String, String]]]{
+class HBaseResultToListConverter extends Converter[Any, java.util.List[java.util.Map[String, String]]]{
   override def convert(obj: Any): java.util.List[java.util.Map[String, String]] = {
     import collection.JavaConverters._
     val result = obj.asInstanceOf[Result]
@@ -102,8 +103,15 @@ class HBaseRawResultsConverter extends Converter[Any, java.util.List[java.util.M
 }
 
 /**
- * Map of "columnFamily:column"->"value" consistent with Python dict
- * Only works with 1 version max.  Ser/deser as python dict naturally, via HashMap
+ * Implementation of [[org.apache.spark.api.python.Converter]] that converts all 
+ * the records in an HBase Result into a Map of "columnFamily:column"->"value" consistent
+ * with a Python dict.
+ * 
+ * Only works with 1 version max (possibly latest if multiple are returned?).  
+ * Ser/deser as python dict naturally, via HashMap.
+ *
+ * Values are returned as raw bytes rather than as printable versions, and thus
+ * may require unpacking.
  */
 class HBaseResultToMapConverter extends Converter[Any, java.util.Map[String, String]]{
   override def convert(obj: Any): java.util.Map[String, String] = {

--- a/src/main/scala/examples/pythonConverters.scala
+++ b/src/main/scala/examples/pythonConverters.scala
@@ -54,6 +54,25 @@ class HBaseResultToStringConverter extends Converter[Any, String]{
   }
 }
 
+class HBaseResultToJSONConverter extends Converter[Any, String]{
+  override def convert(obj: Any): String = {
+    import collection.JavaConverters._
+    val result = obj.asInstanceOf[Result]
+    val output = result.listCells.asScala.map(cell =>
+        Map(
+          "row" -> Bytes.toStringBinary(CellUtil.cloneFamily(cell)),
+          "columnFamily" -> Bytes.toStringBinary(CellUtil.cloneFamily(cell)),
+          "qualifier" -> Bytes.toStringBinary(CellUtil.cloneQualifier(cell)),
+          "timestamp" -> cell.getTimestamp.toString,
+          "type" -> Type.codeToType(cell.getTypeByte).toString,
+          "value" -> Bytes.toStringBinary(CellUtil.cloneValue(cell))
+        )
+      )
+    // output is a JSON array of objects (maps)
+    "[" + output.map(JSONObject(_).toString()).mkString(", ") + "]"
+  }
+}
+
 class HBaseRawResultsConverter extends Converter[Any, java.util.List[java.util.Map[String, String]]]{
   override def convert(obj: Any): java.util.List[java.util.Map[String, String]] = {
     import collection.JavaConverters._

--- a/src/main/scala/examples/pythonConverters.scala
+++ b/src/main/scala/examples/pythonConverters.scala
@@ -93,6 +93,17 @@ class HBaseResultToMapConverter extends Converter[Any, java.util.Map[String, Str
   }
 }
 
+/* Returns the most recent cell timestamp on the row */
+class MaxHBaseTimestamp extends Converter[Any, Long]{
+  override def convert(obj: Any): Long = {
+    import collection.JavaConverters._
+    val result = obj.asInstanceOf[Result]
+    result.listCells.asScala.map(cell =>
+        cell.getTimestamp
+      ).max
+  }
+}
+
 /**
  * Implementation of [[org.apache.spark.api.python.Converter]] that converts an
  * ImmutableBytesWritable to a String


### PR DESCRIPTION
@GenTang would you be interested in pulling and updating on spark-packages.org?  I still haven't seen something as simple for python wrappers, though I am new to this tech stack, so I would think this is widely useful.

I have added a few options similar to yours that work as JSON arrays (#3) as well as getting raw list/dict support in Python without passing through strings.

I updated build to hbase 1.0 as well, unclear to me best protocol here.

I could use a good review since this is the only Scala work I have completed, so feel free to comment on syntax etc.  Any suggestions for testing also welcome.
